### PR TITLE
商品購入確認ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/modules/_items_buy.scss
+++ b/app/assets/stylesheets/modules/_items_buy.scss
@@ -1,0 +1,131 @@
+.item-buy-container {
+  background-color: $background-beige;
+  padding: 0 0 220px;
+  position: relative;
+}
+.confirm-buy {
+  width: 700px;
+  margin: auto;
+  background-color: $background-white;
+  &__header {
+    text-align: center;
+    font-size: 22px;
+    font-weight: bold;
+    line-height: 1;
+    padding: 16px;
+  }
+  &__item {
+    border-top: $border-gray solid 1px;
+    padding: 24px 12.5% 40px;
+    &__content {
+      width: 320px;
+      margin: auto;
+      &__head {
+        font-weight: bold;
+        display: flex;
+        &__img {
+          width: 64px;
+        }
+        &__name {
+          margin-left: 16px;
+          font-size: 16px;
+          line-height: 1.5;
+        }
+      }
+      &__price {
+        text-align: center;
+        font-size: 22px;
+        font-weight: bold;
+        margin-top: 8px;
+        line-height: 1.5;
+        &__fee {
+          margin-left: 8px;
+          font-size: 14px;
+          font-weight: normal;
+        }
+      }
+      &__point {
+        margin-top: 8px;
+        height: 48px;
+        font-size: 14px;
+        text-align: center;
+        line-height: 48px;
+        background-color: $icon-gray;
+      }
+      &__payment {
+        height: 60px;
+        font-weight: bold;
+        margin-top: 16px;
+        display: flex;
+        justify-content: space-between;
+        &__title {
+          font-size: 18px;
+        }
+        &__amount {
+          font-size: 28px;
+        }
+      }
+    }
+    &__buy {
+      display: block;
+      height: 48px;
+      width: 320px;
+      margin: auto;
+      background-color: $mercari-red;
+      color: $text-white;
+      font-size: 14px;
+      font-weight: bold;
+      border: $mercari-red;
+    }
+  }
+  &__delivery {
+    border-top: $border-gray solid 1px;
+    padding: 24px 12.5% 40px;
+    font-size: 14px;
+    &__content {
+      width: 320px;
+      margin: auto;
+      &__title {
+        font-weight: bold;
+      }
+      &__info {
+        margin-top: 8px;
+        line-height: 1.3;
+      }
+      &__edit {
+        text-align: right;
+        &__link {
+          color: $link-skyblue;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+  &__payment {
+    border-top: $border-gray solid 1px;
+    padding: 24px 12.5% 40px;
+    font-size: 14px;
+    &__content {
+      width: 320px;
+      margin: auto;
+      &__title {
+        font-weight: bold;
+      }
+      &__creditcard {
+        margin-top: 8px;
+        line-height: 1.3;
+      }
+      &__edit {
+        text-align: right;
+        &__link {
+          color: $link-skyblue;
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -1,0 +1,1 @@
+hello world

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -1,1 +1,51 @@
-hello world
+.item-buy-container
+  = render 'shared/logo_header'
+  .confirm-buy
+    %h2.confirm-buy__header 購入内容の確認
+    =form_with url:'/', local: true ,class: "confirm-buy__item" do |f|
+      .confirm-buy__item__content
+        %h3.confirm-buy__item__content__head
+          =image_tag 'http://placehold.jp/e8aee3/ffffff/64x95.png', class: "confirm-buy__item__content__head__img"
+          %p.confirm-buy__item__content__head__name メルカリメルカリメルカリメルカリメルカリメルカリメルカリメルカリメルカリメルカリメルカリメルカリ
+        %p.confirm-buy__item__content__price
+          =number_to_currency(2350, :unit => '¥', :precision =>0)
+          %span.confirm-buy__item__content__price__fee 送料込み
+          -# FIXME: 配送料の負担が購入者か出品者かで表示を変える
+          -# %span.confirm-buy__item__content__price__fee 着払い
+        .confirm-buy__item__content__point ポイントはありません
+        .confirm-buy__item__content__payment
+          %span.confirm-buy__item__content__payment__title 支払い金額
+          %span.confirm-buy__item__content__payment__amount=number_to_currency(2350, :unit => '¥', :precision =>0)
+      = f.submit "購入する", class: "confirm-buy__item__buy", "data-disable-with": "処理中", name: "commit"
+    .confirm-buy__delivery
+      .confirm-buy__delivery__content
+        %h3.confirm-buy__delivery__content__title 配送先
+        .confirm-buy__delivery__content__info
+          -# FIXME: delivery_adoressテーブルの値を取得する
+          %p.confirm-buy__delivery__content__info__postalcode 〒123-4567
+          %p.confirm-buy__delivery__content__info__address 愛知県名古屋市中区栄3-13-20 栄センタービル3Fあああああああああああああああああああああ
+          %p.confirm-buy__delivery__content__info__name テスト 太郎
+        .confirm-buy__delivery__content__edit
+          =link_to '', class: "confirm-buy__delivery__content__edit__link" do
+            %span.confirm-buy__delivery__content__edit__link__text 変更する
+            %i.fa.fa-angle-right.confirm-buy__delivery__content__edit__link__arrow{"aria-hidden": "true"}
+    .confirm-buy__payment
+      .confirm-buy__payment__content
+        %h3.confirm-buy__payment__content__title 支払い方法
+        .confirm-buy__payment__content__creditcard
+          -# FIXME: creditcardテーブルの値を取得する
+          %p.confirm-buy__payment__content__creditcard__number ************2050
+          %p.confirm-buy__payment__content__creditcard__limit 02/21
+          -# FIXME: 登録されているクレジットカードのブランドによってロゴを変える
+          = image_tag "visa.svg", size: "49x20"
+          -# = image_tag "master-card.svg", size: "34x20"
+          -# = image_tag "saison-card.svg", size: "30x20"
+          -# = image_tag "jcb.svg", size: "32x20"
+          -# = image_tag "american_express.svg", size: "21x20"
+          -# = image_tag "dinersclub.svg", size: "32x20"
+          -# = image_tag "discover.svg", size: "32x20"
+        .confirm-buy__payment__content__edit
+          =link_to '', class: "confirm-buy__payment__content__edit__link" do
+            %span.confirm-buy__payment__content__edit__link__text 変更する
+            %i.fa.fa-angle-right.confirm-buy__payment__content__edit__link__arrow{"aria-hidden": "true"}
+  = render 'shared/logo-footer'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -146,15 +146,15 @@ ja:
       submit: 保存する
       update: 更新する
   number:
-    currency:
-      format:
-        delimiter: ","
-        format: "%n%u"
-        precision: 0
-        separator: "."
-        significant: false
-        strip_insignificant_zeros: false
-        unit: 円
+    # currency:
+    #   format:
+    #     delimiter: ","
+    #     format: "%n%u"
+    #     precision: 0
+    #     separator: "."
+    #     significant: false
+    #     strip_insignificant_zeros: false
+    #     unit: 円
     format:
       delimiter: ","
       precision: 3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       get 'get_category_children' 
       get 'get_category_grandchildren'
     end
+    get :buy, on: :member
   end
 
   get 'children_category' => 'categories#set_children'


### PR DESCRIPTION
# WHAT
商品購入時の確認ページを作成する

# WHY
商品詳細画面からワンクリックで決済が完了してしまうのは問題があるため、
決済前に確認ページを挟むことで、
支払方法を選択可能にしたり、購入意思の再確認ができるようにする。