### PR TITLE
軽微な修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,25 +1,23 @@
 class UsersController < ApplicationController
   before_action :get_category_parents
+  before_action :set_user, only: [:show, :edit, :update, :show_creditcard]
 
   def new
 
   end
 
   def show
-    user = User.find(params[:id])
-    @nickname = user.nickname
+    @nickname = @user.nickname
   end
 
   def edit
-    user = User.find(params[:id])
-    @nickname = user.nickname
-    @profile = user.profile
+    @nickname = @user.nickname
+    @profile = @user.profile
   end
 
   def update
-    user = User.find(params[:id])
-    if user.id == current_user.id
-      user.update(user_edit_params)
+    if @user.id == current_user.id
+      @user.update(user_edit_params)
       redirect_to edit_user_path(current_user), notice: 'プロフィールを変更しました'
     end
   end
@@ -29,8 +27,7 @@ class UsersController < ApplicationController
   end
 
   def show_creditcard
-    user = User.find(params[:id])
-    @creditcards = user.creditcards
+    @creditcards = @user.creditcards
     if @creditcards.length > 0 
       # クレジットカード番号の先頭から12桁までを*に置換する
       @creditcards[0].credit_number = @creditcards[0].credit_number.sub(/[0-9]{12}/,"************")
@@ -55,5 +52,9 @@ class UsersController < ApplicationController
 
   def user_edit_params
     params.permit(:nickname, :profile)
+  end
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,8 @@ class UsersController < ApplicationController
   end
 
   def show
+    user = User.find(params[:id])
+    @nickname = user.nickname
   end
 
   def edit

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -14,22 +14,22 @@
         %h2.top-content__items__class__title 人気のカテゴリー
         %ul.top-content__items__class__detail
           %li.top-content__items__class__detail__list
-            =link_to "レディース", '', class: "top-content__items__class__detail__list__link"
+            =link_to "レディース", '#top-lady', class: "top-content__items__class__detail__list__link"
           %li.top-content__items__class__detail__list
-            =link_to "メンズ", '', class: "top-content__items__class__detail__list__link"
+            =link_to "メンズ", '#top-mens', class: "top-content__items__class__detail__list__link"
           %li.top-content__items__class__detail__list
-            =link_to "インテリア・住まい・小物", '', class: "top-content__items__class__detail__list__link"
+            =link_to "インテリア・住まい・小物", '#top-interiors', class: "top-content__items__class__detail__list__link"
           %li.top-content__items__class__detail__list
-            =link_to "ベビー・キッズ", '', class: "top-content__items__class__detail__list__link"
+            =link_to "ベビー・キッズ", '#top-babies', class: "top-content__items__class__detail__list__link"
       .top-content__items__list
         = render partial: 'item_card'
-      .top-content__items__list
+      #top-lady.top-content__items__list
         = render partial: 'item_card_lady'
-      .top-content__items__list
+      #top-mens.top-content__items__list
         = render partial: 'item_card_mens'
-      .top-content__items__list
+      #top-interiors.top-content__items__list
         = render partial: 'item_card_interiors'
-      .top-content__items__list
+      #top-babies.top-content__items__list
         = render partial: 'item_card_babies'
     = render 'shared/global_footer'
     = render 'shared/sell_button'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -86,7 +86,7 @@
     - if @item.buyer_id
       .item-box__sold 売り切れました
     - else
-      =link_to "購入画面に進む", '', class: "item-box__buy"
+      =link_to "購入画面に進む", buy_item_path(@item), class: "item-box__buy"
     .item-box__description
       %p
         ご覧いただきありがとうございます！

--- a/app/views/shared/_logo_header.html.haml
+++ b/app/views/shared/_logo_header.html.haml
@@ -1,5 +1,5 @@
 .input
   .input__header
     .input__header--logo
-      = link_to "#" do
+      = link_to root_path do
         = image_tag "logo.svg", size: "185x49", alt: "mercari",class: "logo-opacity" 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,7 +8,7 @@
       .mypage-content__main__userinfo
         =link_to '', class: "mypage-content__main__userinfo__link" do
           =image_tag 'member_photo_noimage_thumb.png', class: "mypage-content__main__userinfo__link__img"
-          %p.mypage-content__main__userinfo__link__username テストユーザー
+          %p.mypage-content__main__userinfo__link__username=@nickname
           .mypage-content__main__userinfo__link__counter
             .mypage-content__main__userinfo__link__counter__rating
               評価


### PR DESCRIPTION
# WHAT
1. 商品詳細画面から購入確認画面へのリンク修正
1. 商品購入確認画面のヘッダーロゴ押下でトップページに遷移させる
1. マイページにログインユーザーのニックネームを表示する
1. トップページの「人気のカテゴリー」押下でトップページの各カテゴリーの商品リストにジャンプさせる

# WHY
1. 商品詳細画面から購入確認画面へのリンクが抜けており、ユーザーが購入確認画面にアクセスできないため
1. ヘッダーロゴ押下でトップページに戻ることでユーザビリティの向上が見込めるため
1. 現在どのユーザーでログインしているのかを確認できるようにするため
1. ユーザビリティの向上が見込めるため